### PR TITLE
Somehow missed adding the actual bme280 dependency.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+bme280
 smbus2
 Django==2.1.2
 djangorestframework


### PR DESCRIPTION
Whoops.