### PR TITLE
Adding caching to the BME280 class.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+cachetools
 RPi.bme280
 smbus2
 Django==2.1.2


### PR DESCRIPTION
 Average response time is 1s as stated on the BME280 spec sheet, so I've set the cache TTL to 2s to allow for some buffer.